### PR TITLE
Add truncate functionality

### DIFF
--- a/sitemap/adder.go
+++ b/sitemap/adder.go
@@ -13,7 +13,7 @@ import (
 
 type DefaultAdder struct{}
 
-func (a *DefaultAdder) Add(oldSitemap io.Reader, url URL) (fileName string, err error) {
+func (a *DefaultAdder) Add(oldSitemap io.Reader, url *URL) (fileName string, err error) {
 	// create a temporary file
 	file, err := os.CreateTemp("", "sitemap-incr")
 	if err != nil {
@@ -50,7 +50,9 @@ func (a *DefaultAdder) Add(oldSitemap io.Reader, url URL) (fileName string, err 
 	}
 
 	// add new URL
-	sitemap.URL = append(sitemap.URL, url)
+	if url != nil {
+		sitemap.URL = append(sitemap.URL, *url)
+	}
 
 	// output result into the file
 	_, err = file.WriteString(xml.Header)

--- a/sitemap/adder_test.go
+++ b/sitemap/adder_test.go
@@ -14,7 +14,7 @@ func TestAdder(t *testing.T) {
 		oldSitemap := strings.NewReader("<<<")
 
 		a := &sitemap.DefaultAdder{}
-		filename, err := a.Add(oldSitemap, sitemap.URL{})
+		filename, err := a.Add(oldSitemap, nil)
 
 		Convey("Adder should return correct error", func() {
 			So(err.Error(), ShouldContainSubstring, "failed to decode old sitemap")
@@ -31,7 +31,7 @@ func TestAdder(t *testing.T) {
 		oldSitemap := strings.NewReader("")
 
 		a := &sitemap.DefaultAdder{}
-		filename, err := a.Add(oldSitemap, sitemap.URL{Loc: "a", Lastmod: "b"})
+		filename, err := a.Add(oldSitemap, &sitemap.URL{Loc: "a", Lastmod: "b"})
 		defer func() {
 			removeErr := os.Remove(filename)
 			So(removeErr, ShouldBeNil)
@@ -71,7 +71,7 @@ func TestAdder(t *testing.T) {
 		</urlset>`)
 
 		a := &sitemap.DefaultAdder{}
-		filename, err := a.Add(oldSitemap, sitemap.URL{Loc: "e", Lastmod: "f"})
+		filename, err := a.Add(oldSitemap, &sitemap.URL{Loc: "e", Lastmod: "f"})
 		defer func() {
 			removeErr := os.Remove(filename)
 			So(removeErr, ShouldBeNil)
@@ -101,6 +101,50 @@ func TestAdder(t *testing.T) {
   <url>
     <loc>e</loc>
     <lastmod>f</lastmod>
+  </url>
+</urlset>`)
+		})
+	})
+	Convey("When no url is passed", t, func() {
+		oldSitemap := strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+		<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+		  <url>
+			<loc>a</loc>
+			<lastmod>b</lastmod>
+		  </url>
+		  <url>
+		  <loc>c</loc>
+		  <lastmod>d</lastmod>
+		</url>
+		</urlset>`)
+
+		a := &sitemap.DefaultAdder{}
+		filename, err := a.Add(oldSitemap, nil)
+		defer func() {
+			removeErr := os.Remove(filename)
+			So(removeErr, ShouldBeNil)
+		}()
+
+		Convey("Adder should return with no error", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("Temporary sitemap file should be created and available", func() {
+			So(filename, ShouldContainSubstring, "sitemap")
+			_, err := os.Stat(filename)
+			So(err, ShouldBeNil)
+		})
+		Convey("Sitemap should be valid and include same urls as before", func() {
+			sitemapContent, err := os.ReadFile(filename)
+			So(err, ShouldBeNil)
+			So(string(sitemapContent), ShouldEqual, `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>a</loc>
+    <lastmod>b</lastmod>
+  </url>
+  <url>
+    <loc>c</loc>
+    <lastmod>d</lastmod>
   </url>
 </urlset>`)
 		})

--- a/sitemap/generator.go
+++ b/sitemap/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/ONSdigital/dp-sitemap/config"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -27,7 +28,7 @@ type Fetcher interface {
 	URLVersions(ctx context.Context, path string, lastmod string) (en URL, cy *URL)
 }
 type Adder interface {
-	Add(oldSitemap io.Reader, url URL) (string, error)
+	Add(oldSitemap io.Reader, url *URL) (string, error)
 }
 
 type Generator struct {
@@ -62,10 +63,14 @@ func (g *Generator) MakeIncrementalSitemap(ctx context.Context, name string, url
 		url.Lastmod,
 	)
 
-	return g.AppendURL(ctx, currentSitemap, urlEn, name)
+	return g.AppendURL(ctx, currentSitemap, &urlEn, name)
 }
 
-func (g *Generator) AppendURL(ctx context.Context, sitemap io.ReadCloser, url URL, destination string) error {
+func (g *Generator) TruncateIncrementalSitemap(ctx context.Context, name string) error {
+	return g.AppendURL(ctx, io.NopCloser(strings.NewReader("")), nil, name)
+}
+
+func (g *Generator) AppendURL(ctx context.Context, sitemap io.ReadCloser, url *URL, destination string) error {
 	fileName, err := g.adder.Add(sitemap, url)
 	if err != nil {
 		return fmt.Errorf("failed to add to sitemap: %w", err)

--- a/sitemap/generator_test.go
+++ b/sitemap/generator_test.go
@@ -90,7 +90,7 @@ func TestGenerateIncrementalSitemap(t *testing.T) {
 		}
 		var tempFile string
 		adder.AddFunc = func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
-			So(url, ShouldResemble, sitemap.URL{Loc: "a", Lastmod: "b"})
+			So(url, ShouldResemble, &sitemap.URL{Loc: "a", Lastmod: "b"})
 			file, err := os.CreateTemp("", "sitemap-incr")
 			So(err, ShouldBeNil)
 			file.WriteString("file content")

--- a/sitemap/generator_test.go
+++ b/sitemap/generator_test.go
@@ -53,7 +53,7 @@ func TestGenerateIncrementalSitemap(t *testing.T) {
 		store.GetFileFunc = func(name string) (io.ReadCloser, error) {
 			return io.NopCloser(strings.NewReader("")), nil
 		}
-		adder.AddFunc = func(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+		adder.AddFunc = func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 			return "", errors.New("adder error")
 		}
 
@@ -70,7 +70,7 @@ func TestGenerateIncrementalSitemap(t *testing.T) {
 		store.GetFileFunc = func(name string) (io.ReadCloser, error) {
 			return io.NopCloser(strings.NewReader("")), nil
 		}
-		adder.AddFunc = func(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+		adder.AddFunc = func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 			return "filename", nil
 		}
 
@@ -89,7 +89,7 @@ func TestGenerateIncrementalSitemap(t *testing.T) {
 			return io.NopCloser(strings.NewReader("")), nil
 		}
 		var tempFile string
-		adder.AddFunc = func(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+		adder.AddFunc = func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 			So(url, ShouldResemble, sitemap.URL{Loc: "a", Lastmod: "b"})
 			file, err := os.CreateTemp("", "sitemap-incr")
 			So(err, ShouldBeNil)
@@ -129,7 +129,7 @@ func TestGenerateIncrementalSitemap(t *testing.T) {
 			return io.NopCloser(strings.NewReader("")), nil
 		}
 		var tempFile string
-		adder.AddFunc = func(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+		adder.AddFunc = func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 			file, err := os.CreateTemp("", "sitemap-incr")
 			So(err, ShouldBeNil)
 			file.WriteString("file content")

--- a/sitemap/mock/adder.go
+++ b/sitemap/mock/adder.go
@@ -19,7 +19,7 @@ var _ sitemap.Adder = &AdderMock{}
 //
 // 		// make and configure a mocked sitemap.Adder
 // 		mockedAdder := &AdderMock{
-// 			AddFunc: func(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+// 			AddFunc: func(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 // 				panic("mock out the Add method")
 // 			},
 // 		}
@@ -30,7 +30,7 @@ var _ sitemap.Adder = &AdderMock{}
 // 	}
 type AdderMock struct {
 	// AddFunc mocks the Add method.
-	AddFunc func(oldSitemap io.Reader, url sitemap.URL) (string, error)
+	AddFunc func(oldSitemap io.Reader, url *sitemap.URL) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -39,20 +39,20 @@ type AdderMock struct {
 			// OldSitemap is the oldSitemap argument value.
 			OldSitemap io.Reader
 			// URL is the url argument value.
-			URL sitemap.URL
+			URL *sitemap.URL
 		}
 	}
 	lockAdd sync.RWMutex
 }
 
 // Add calls AddFunc.
-func (mock *AdderMock) Add(oldSitemap io.Reader, url sitemap.URL) (string, error) {
+func (mock *AdderMock) Add(oldSitemap io.Reader, url *sitemap.URL) (string, error) {
 	if mock.AddFunc == nil {
 		panic("AdderMock.AddFunc: method is nil but Adder.Add was just called")
 	}
 	callInfo := struct {
 		OldSitemap io.Reader
-		URL        sitemap.URL
+		URL        *sitemap.URL
 	}{
 		OldSitemap: oldSitemap,
 		URL:        url,
@@ -68,11 +68,11 @@ func (mock *AdderMock) Add(oldSitemap io.Reader, url sitemap.URL) (string, error
 //     len(mockedAdder.AddCalls())
 func (mock *AdderMock) AddCalls() []struct {
 	OldSitemap io.Reader
-	URL        sitemap.URL
+	URL        *sitemap.URL
 } {
 	var calls []struct {
 		OldSitemap io.Reader
-		URL        sitemap.URL
+		URL        *sitemap.URL
 	}
 	mock.lockAdd.RLock()
 	calls = mock.calls.Add


### PR DESCRIPTION
Add truncate functionality to the incremental sitemap.
This is meant to be used when we regenerate the full sitemap to avoid URL duplication.