### PR TITLE
Delete temp sitemap after copying on kafka event

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ This repo holds all information/code regarding sitemap (for SEO and other purpos
 
 # Structure of robot.json
 Holds allow/deny list for different user-agents.
-```
+
+```json
 {
     "Googlebot": {
       "AllowList": ["/googleallow1", "/googleallow2"],

--- a/event/handler.go
+++ b/event/handler.go
@@ -83,6 +83,11 @@ func (h *ContentPublishedHandler) createSiteMap(ctx context.Context, lang config
 		return err
 	}
 
+	err = h.fileStore.DeleteFile(tmpSitemapName)
+	if err != nil {
+		log.Error(ctx, "Error deleting temp sitemap", err)
+	}
+
 	return nil
 }
 

--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -2,15 +2,16 @@ package event
 
 import (
 	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	mock2 "github.com/ONSdigital/dp-sitemap/clients/mock"
 	"github.com/ONSdigital/dp-sitemap/config"
 	"github.com/ONSdigital/dp-sitemap/sitemap"
 	"github.com/ONSdigital/dp-sitemap/sitemap/mock"
-	"io"
-	"os"
-	"strings"
-	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -55,6 +56,10 @@ func TestHandle(t *testing.T) {
 		}
 
 		store.CopyFileFunc = func(src io.Reader, dest io.Writer) error {
+			return nil
+		}
+
+		store.DeleteFileFunc = func(name string) error {
 			return nil
 		}
 

--- a/sitemap/generator.go
+++ b/sitemap/generator.go
@@ -23,6 +23,7 @@ type FileStore interface {
 	GetFile(name string) (body io.ReadCloser, err error)
 	CopyFile(src io.Reader, dest io.Writer) error
 	CreateFile(name string) (io.ReadWriteCloser, error)
+	DeleteFile(name string) error
 }
 
 type Fetcher interface {

--- a/sitemap/localstore.go
+++ b/sitemap/localstore.go
@@ -55,3 +55,11 @@ func (s *LocalStore) CreateFile(name string) (io.ReadWriteCloser, error) {
 	}
 	return file, nil
 }
+
+func (s *LocalStore) DeleteFile(name string) error {
+	err := os.Remove(name)
+	if err != nil {
+		return fmt.Errorf("failed to delete file : %w", err)
+	}
+	return nil
+}

--- a/sitemap/localstore_test.go
+++ b/sitemap/localstore_test.go
@@ -100,4 +100,30 @@ func TestLocalStore(t *testing.T) {
 			So(string(content), ShouldEqual, "file content")
 		})
 	})
+
+	Convey("When a file deletion succeeds", t, func() {
+
+		randomFilename := path.Join(dir, "sitemap-test-"+uuid.NewString())
+		err := os.WriteFile(randomFilename, []byte("file content"), 0o600)
+
+		s := &sitemap.LocalStore{}
+		err = s.DeleteFile(randomFilename)
+
+		Convey("Localstore should not return an error", func() {
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("When an incorrect path is provided for deletion", t, func() {
+
+		randomFilename := path.Join(dir, "sitemap-test-"+uuid.NewString())
+
+		s := &sitemap.LocalStore{}
+		err := s.DeleteFile(randomFilename)
+
+		Convey("Localstore should not return an error", func() {
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "failed to delete file")
+		})
+	})
 }

--- a/sitemap/mock/filestore.go
+++ b/sitemap/mock/filestore.go
@@ -25,6 +25,9 @@ var _ sitemap.FileStore = &FileStoreMock{}
 //			CreateFileFunc: func(name string) (io.ReadWriteCloser, error) {
 //				panic("mock out the CreateFile method")
 //			},
+//			DeleteFileFunc: func(name string) error {
+//				panic("mock out the DeleteFile method")
+//			},
 //			GetFileFunc: func(name string) (io.ReadCloser, error) {
 //				panic("mock out the GetFile method")
 //			},
@@ -43,6 +46,9 @@ type FileStoreMock struct {
 
 	// CreateFileFunc mocks the CreateFile method.
 	CreateFileFunc func(name string) (io.ReadWriteCloser, error)
+
+	// DeleteFileFunc mocks the DeleteFile method.
+	DeleteFileFunc func(name string) error
 
 	// GetFileFunc mocks the GetFile method.
 	GetFileFunc func(name string) (io.ReadCloser, error)
@@ -64,6 +70,11 @@ type FileStoreMock struct {
 			// Name is the name argument value.
 			Name string
 		}
+		// DeleteFile holds details about calls to the DeleteFile method.
+		DeleteFile []struct {
+			// Name is the name argument value.
+			Name string
+		}
 		// GetFile holds details about calls to the GetFile method.
 		GetFile []struct {
 			// Name is the name argument value.
@@ -79,6 +90,7 @@ type FileStoreMock struct {
 	}
 	lockCopyFile   sync.RWMutex
 	lockCreateFile sync.RWMutex
+	lockDeleteFile sync.RWMutex
 	lockGetFile    sync.RWMutex
 	lockSaveFile   sync.RWMutex
 }
@@ -148,6 +160,38 @@ func (mock *FileStoreMock) CreateFileCalls() []struct {
 	mock.lockCreateFile.RLock()
 	calls = mock.calls.CreateFile
 	mock.lockCreateFile.RUnlock()
+	return calls
+}
+
+// DeleteFile calls DeleteFileFunc.
+func (mock *FileStoreMock) DeleteFile(name string) error {
+	if mock.DeleteFileFunc == nil {
+		panic("FileStoreMock.DeleteFileFunc: method is nil but FileStore.DeleteFile was just called")
+	}
+	callInfo := struct {
+		Name string
+	}{
+		Name: name,
+	}
+	mock.lockDeleteFile.Lock()
+	mock.calls.DeleteFile = append(mock.calls.DeleteFile, callInfo)
+	mock.lockDeleteFile.Unlock()
+	return mock.DeleteFileFunc(name)
+}
+
+// DeleteFileCalls gets all the calls that were made to DeleteFile.
+// Check the length with:
+//
+//	len(mockedFileStore.DeleteFileCalls())
+func (mock *FileStoreMock) DeleteFileCalls() []struct {
+	Name string
+} {
+	var calls []struct {
+		Name string
+	}
+	mock.lockDeleteFile.RLock()
+	calls = mock.calls.DeleteFile
+	mock.lockDeleteFile.RUnlock()
 	return calls
 }
 

--- a/sitemap/mock/s3client.go
+++ b/sitemap/mock/s3client.go
@@ -16,25 +16,25 @@ var _ sitemap.S3Client = &S3ClientMock{}
 
 // S3ClientMock is a mock implementation of sitemap.S3Client.
 //
-// 	func TestSomethingThatUsesS3Client(t *testing.T) {
+//	func TestSomethingThatUsesS3Client(t *testing.T) {
 //
-// 		// make and configure a mocked sitemap.S3Client
-// 		mockedS3Client := &S3ClientMock{
-// 			BucketNameFunc: func() string {
-// 				panic("mock out the BucketName method")
-// 			},
-// 			GetFunc: func(key string) (io.ReadCloser, *int64, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 			UploadFunc: func(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-// 				panic("mock out the Upload method")
-// 			},
-// 		}
+//		// make and configure a mocked sitemap.S3Client
+//		mockedS3Client := &S3ClientMock{
+//			BucketNameFunc: func() string {
+//				panic("mock out the BucketName method")
+//			},
+//			GetFunc: func(key string) (io.ReadCloser, *int64, error) {
+//				panic("mock out the Get method")
+//			},
+//			UploadFunc: func(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+//				panic("mock out the Upload method")
+//			},
+//		}
 //
-// 		// use mockedS3Client in code that requires sitemap.S3Client
-// 		// and then make assertions.
+//		// use mockedS3Client in code that requires sitemap.S3Client
+//		// and then make assertions.
 //
-// 	}
+//	}
 type S3ClientMock struct {
 	// BucketNameFunc mocks the BucketName method.
 	BucketNameFunc func() string
@@ -83,7 +83,8 @@ func (mock *S3ClientMock) BucketName() string {
 
 // BucketNameCalls gets all the calls that were made to BucketName.
 // Check the length with:
-//     len(mockedS3Client.BucketNameCalls())
+//
+//	len(mockedS3Client.BucketNameCalls())
 func (mock *S3ClientMock) BucketNameCalls() []struct {
 } {
 	var calls []struct {
@@ -112,7 +113,8 @@ func (mock *S3ClientMock) Get(key string) (io.ReadCloser, *int64, error) {
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedS3Client.GetCalls())
+//
+//	len(mockedS3Client.GetCalls())
 func (mock *S3ClientMock) GetCalls() []struct {
 	Key string
 } {
@@ -145,7 +147,8 @@ func (mock *S3ClientMock) Upload(input *s3manager.UploadInput, options ...func(*
 
 // UploadCalls gets all the calls that were made to Upload.
 // Check the length with:
-//     len(mockedS3Client.UploadCalls())
+//
+//	len(mockedS3Client.UploadCalls())
 func (mock *S3ClientMock) UploadCalls() []struct {
 	Input   *s3manager.UploadInput
 	Options []func(*s3manager.Uploader)

--- a/sitemap/s3store.go
+++ b/sitemap/s3store.go
@@ -54,3 +54,7 @@ func (s *S3Store) CopyFile(_ io.Reader, _ io.Writer) error {
 func (s *S3Store) CreateFile(_ string) (io.ReadWriteCloser, error) {
 	return nil, nil
 }
+
+func (s *S3Store) DeleteFile(_ string) error {
+	return nil
+}


### PR DESCRIPTION
### What

When running in localstore mode and consuming kafka events - delete temporary sitemap interations.

### How to review

Check tests ok, code looks ok - you can run it locally by consuming a content-updated event and seeing that the tmp file is removed. 

### Who can review

Not me. 